### PR TITLE
ScheduleActivity Warning Bash

### DIFF
--- a/app/src/main/kotlin/co/touchlab/droidconandroid/FilterableScheduleActivity.kt
+++ b/app/src/main/kotlin/co/touchlab/droidconandroid/FilterableScheduleActivity.kt
@@ -74,7 +74,7 @@ class FilterableScheduleActivity : ScheduleActivity(), FilterInterface
         {
             override fun onFilterClick(track: Track)
             {
-                pagerAdapter !!.updateFrags(track)
+                (view_pager.adapter as ScheduleFragmentPagerAdapter).updateFrags(track)
             }
         })
         filter_recycler.adapter = filterAdapter

--- a/app/src/main/kotlin/co/touchlab/droidconandroid/SignInActivity.kt
+++ b/app/src/main/kotlin/co/touchlab/droidconandroid/SignInActivity.kt
@@ -113,7 +113,7 @@ public class SignInActivity : AppCompatActivity(), LoginScreenPresenter.Host {
     {
         if (!failed) {
             finish()
-            ScheduleActivity.startMe(this)
+            startScheduleActivity(this)
             if (firstLogin)
                 EditUserProfile.callMe(this)
         }
@@ -228,7 +228,7 @@ public class SignInActivity : AppCompatActivity(), LoginScreenPresenter.Host {
         mResolvingError = false;
     }
 
-    public inner class ErrorDialogFragment : DialogFragment() {
+    inner class ErrorDialogFragment : DialogFragment() {
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             val errorCode = this.getArguments().getInt(DIALOG_ERROR);

--- a/app/src/main/kotlin/co/touchlab/droidconandroid/UserDetailActivity.kt
+++ b/app/src/main/kotlin/co/touchlab/droidconandroid/UserDetailActivity.kt
@@ -38,7 +38,7 @@ class UserDetailActivity : AppCompatActivity(), UserDetailFragment.Companion.Fin
     {
         if (isTaskRoot())
         {
-            ScheduleActivity.startMe(this)
+            startScheduleActivity(this)
         }
 
         finish()

--- a/app/src/main/kotlin/co/touchlab/droidconandroid/WelcomeActivity.kt
+++ b/app/src/main/kotlin/co/touchlab/droidconandroid/WelcomeActivity.kt
@@ -85,7 +85,7 @@ public class WelcomeActivity : AppCompatActivity()
             when(position) {
                 lastIndex -> {
 //                    if(!short)
-                        ScheduleActivity.startMe(this@WelcomeActivity)
+                    startScheduleActivity(this@WelcomeActivity)
                     finish()
                 }
                 else -> {


### PR DESCRIPTION
Resolves all warnings in ScheduleActivity.kt as well as some light refactoring. Most of the warnings are trivial things like redundant semicolons and use of properties. Refactoring includes moving event bus receivers further down in the file so they dont split the lifecycle methods. Moving the startMe function out to package level. Access adapters from their parents rather than keeping a possibly null reference around
