### PR TITLE
Remove iOS nav bar bottom shadow

### DIFF
--- a/ios/ios/ViewController.m
+++ b/ios/ios/ViewController.m
@@ -41,6 +41,10 @@
     [self loadConferenceSchedule];
     self.tableView.delegate = self.platformContext;
     self.tableView.dataSource = self.platformContext;
+    
+    // Hide the nav bar shadow
+    [self.navigationController.navigationBar setShadowImage:[[UIImage alloc] init]];
+    [self.navigationController.navigationBar setBackgroundImage:[[UIImage alloc]init] forBarMetrics:UIBarMetricsDefault];
 }
 
 - (void)createSDASimple


### PR DESCRIPTION
Just a tiny change here to remove the thin line between the navigation bar and tab bar on the main schedule page.
