### PR TITLE
Adds (iOS) toasts

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -42,7 +42,8 @@ pod 'j2objc-intellijannotations-release', :configuration => ['Release'], :path =
     pod 'Fabric'
     pod 'Crashlytics'
     pod 'Google/SignIn'
-    pod 'Kingfisher', '~> 2.4'
+    pod 'Kingfisher', '~> 2.4.1'
+    pod 'Toast-Swift', '~> 1.3.0'
     pod 'Reachability', '~> 3.2'
     pod 'JWPlayer-SDK', '~> 2.4.1'
 end

--- a/ios/ios/EditProfileViewController.swift
+++ b/ios/ios/EditProfileViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Toast_Swift
 
 class EditProfileViewController: UIViewController,  UIImagePickerControllerDelegate, UINavigationControllerDelegate, DCPEditProfileHost {
     
@@ -146,10 +147,9 @@ class EditProfileViewController: UIViewController,  UIImagePickerControllerDeleg
     }
     
     func showMessageWithNSString(msg: String!) {
-        let alertController = UIAlertController(title: msg, message: "", preferredStyle: .Alert)
-        let actionOk = UIAlertAction(title: "OK", style: .Default, handler: nil)
-        alertController.addAction(actionOk)
-        self.presentViewController(alertController, animated: true, completion: nil)
+        var style = ToastStyle()
+        style.backgroundColor = UIColor(red: 0/255.0, green: 65/255.0, blue: 163/255.0, alpha: 1.0)
+        self.view.makeToast(msg, duration: 3.0, position: .Bottom, style: style)
     }
 
 }


### PR DESCRIPTION
Replaces iOS "OK" Alert dialogs with cute Android-style toasts for edit profile screen validation/confirmation messages.

Also, locking Kingfisher @ 2.4.1 for now since the automatic upgrade to 2.4.2 when I ran 'pod install' caused some new build errors -- to be investigated.
