### PR TITLE
Fix crash when speaker userCode is empty

### DIFF
--- a/app/src/main/kotlin/co/touchlab/droidconandroid/EventDetailAdapter.kt
+++ b/app/src/main/kotlin/co/touchlab/droidconandroid/EventDetailAdapter.kt
@@ -192,7 +192,9 @@ class EventDetailAdapter(val context: Context, val frag:EventDetailFragment, val
                 nameView.setTextColor(trackColor)
 
                 speakerVH.itemView.setOnClickListener({
-                    UserDetailActivity.callMe(context as Activity, user.userCode)
+                    if (!TextUtils.isEmpty(user.userCode)) {
+                        UserDetailActivity.callMe(context as Activity, user.userCode)
+                    }
                 })
 
                 val bioSpanned = Html.fromHtml(StringUtils.trimToEmpty(user.bio)!!)

--- a/app/src/main/kotlin/co/touchlab/droidconandroid/UserDetailFragment.kt
+++ b/app/src/main/kotlin/co/touchlab/droidconandroid/UserDetailFragment.kt
@@ -121,7 +121,8 @@ class UserDetailFragment() : Fragment()
             {
                 override fun onSuccess()
                 {
-                    placeholder_emoji.text = ""
+                    if(placeholder_emoji != null)
+                       placeholder_emoji.text = ""
                 }
 
                 override fun onError()


### PR DESCRIPTION
Resolves UserDetailFragment crash when the user clicks on a speaker profile from the event detail screen and the speaker's userCode is empty.

Seems like there are more than a handful of speakers that do not have userCodes -- I've added a card to Trello with a couple of examples.
