### PR TITLE
Fix event detail crash

### DIFF
--- a/lib/src/main/java/co/touchlab/droidconandroid/presenter/EventDetailPresenter.java
+++ b/lib/src/main/java/co/touchlab/droidconandroid/presenter/EventDetailPresenter.java
@@ -75,7 +75,7 @@ public class EventDetailPresenter extends AbstractEventBusPresenter
 
     public void onEventMainThread(EventVideoDetailsTask task)
     {
-        if(task.getEventId() == eventId)
+        if(task.getEventId() == eventId && eventDetailLoadTask != null)
         {
             eventVideoDetailsTask = task;
             host.videoDataRefresh();


### PR DESCRIPTION
Prevents NPE if the user closes and opens a second instance of the same EventDetailFragment before the EventVideoDetailsTask from the first instance completes.